### PR TITLE
feat: nopCommerce plugin scaffold + OutboxMessage entity and migration

### DIFF
--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.Polls", "Pl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nop.Plugin.Misc.Forums", "Plugins\Nop.Plugin.Misc.Forums\Nop.Plugin.Misc.Forums.csproj", "{7F388E1B-598D-49C0-9AED-BC8B64D02D67}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nop.Plugin.Integration.OrderPublisher", "Plugins\Nop.Plugin.Integration.OrderPublisher\Nop.Plugin.Integration.OrderPublisher.csproj", "{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -503,6 +505,18 @@ Global
 		{7F388E1B-598D-49C0-9AED-BC8B64D02D67}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{7F388E1B-598D-49C0-9AED-BC8B64D02D67}.Release|x86.ActiveCfg = Release|Any CPU
 		{7F388E1B-598D-49C0-9AED-BC8B64D02D67}.Release|x86.Build.0 = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -544,6 +558,7 @@ Global
 		{8B4F2F39-3A48-49D4-8A56-A870ECC2BC72} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{0F3F0FB1-FE8F-3390-4558-9BB2B0A807DF} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 		{7F388E1B-598D-49C0-9AED-BC8B64D02D67} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
+		{DDDF9069-7A05-4B6A-BBEA-1474EB084D3F} = {7881B112-7843-4542-B1F7-F99553FB9BB7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE72A8B2-332A-4175-9319-6726D36E9D25}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Mapping/Builders/OutboxMessageBuilder.cs
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Mapping/Builders/OutboxMessageBuilder.cs
@@ -1,0 +1,18 @@
+using FluentMigrator.Builders.Create.Table;
+using Nop.Data.Mapping.Builders;
+using Nop.Plugin.Integration.OrderPublisher.Domain;
+
+namespace Nop.Plugin.Integration.OrderPublisher.Data.Mapping.Builders;
+
+public class OutboxMessageBuilder : NopEntityBuilder<OutboxMessage>
+{
+    public override void MapEntity(CreateTableExpressionBuilder table)
+    {
+        table
+            .WithColumn(nameof(OutboxMessage.EventType)).AsString(100).NotNullable()
+            .WithColumn(nameof(OutboxMessage.Payload)).AsString(int.MaxValue).NotNullable()
+            .WithColumn(nameof(OutboxMessage.CreatedOnUtc)).AsDateTime2().NotNullable()
+            .WithColumn(nameof(OutboxMessage.ProcessedOnUtc)).AsDateTime2().Nullable()
+            .WithColumn(nameof(OutboxMessage.CorrelationId)).AsString(100).NotNullable();
+    }
+}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Mapping/OrderPublisherNameCompatibility.cs
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Mapping/OrderPublisherNameCompatibility.cs
@@ -1,0 +1,14 @@
+using Nop.Data.Mapping;
+using Nop.Plugin.Integration.OrderPublisher.Domain;
+
+namespace Nop.Plugin.Integration.OrderPublisher.Data.Mapping;
+
+public class OrderPublisherNameCompatibility : INameCompatibility
+{
+    public Dictionary<Type, string> TableNames => new()
+    {
+        { typeof(OutboxMessage), "Integration_OutboxMessage" }
+    };
+
+    public Dictionary<(Type, string), string> ColumnName => [];
+}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Migrations/SchemaMigration.cs
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Data/Migrations/SchemaMigration.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using Nop.Data.Extensions;
+using Nop.Data.Mapping;
+using Nop.Data.Migrations;
+using Nop.Plugin.Integration.OrderPublisher.Domain;
+
+namespace Nop.Plugin.Integration.OrderPublisher.Data.Migrations;
+
+[NopMigration("2026-05-17 00:00:00", "Integration.OrderPublisher schema", MigrationProcessType.Installation)]
+public class SchemaMigration : Migration
+{
+    public override void Up()
+    {
+        this.CreateTableIfNotExists<OutboxMessage>();
+    }
+
+    public override void Down()
+    {
+        Delete.Table(NameCompatibilityManager.GetTableName(typeof(OutboxMessage)));
+    }
+}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Domain/OutboxMessage.cs
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Domain/OutboxMessage.cs
@@ -1,0 +1,32 @@
+using Nop.Core;
+
+namespace Nop.Plugin.Integration.OrderPublisher.Domain;
+
+public class OutboxMessage : BaseEntity
+{
+    /// <summary>
+    /// Event type identifier, e.g. "order.placed"
+    /// </summary>
+    public string EventType { get; set; }
+
+    /// <summary>
+    /// JSON-serialised event payload
+    /// </summary>
+    public string Payload { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the message was written to the Outbox
+    /// </summary>
+    public DateTime CreatedOnUtc { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the message was successfully published to RabbitMQ.
+    /// Null means the message is still pending delivery.
+    /// </summary>
+    public DateTime? ProcessedOnUtc { get; set; }
+
+    /// <summary>
+    /// Stable idempotency key — set to OrderId so the consumer can detect duplicates
+    /// </summary>
+    public string CorrelationId { get; set; }
+}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Nop.Plugin.Integration.OrderPublisher.csproj
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/Nop.Plugin.Integration.OrderPublisher.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputPath>$(SolutionDir)\Presentation\Nop.Web\Plugins\Integration.OrderPublisher</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+    <!--Set to true because this plugin will reference RabbitMQ.Client NuGet package-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="plugin.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="plugin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
+    <ClearPluginAssemblies Include="$(SolutionDir)\Build\ClearPluginAssemblies.proj" />
+  </ItemGroup>
+
+  <!-- This target executes after "Build" target -->
+  <Target Name="NopTarget" AfterTargets="Build">
+    <!-- Delete unnecessary libraries from plugins path -->
+    <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(OutDir)" Targets="NopClear" />
+  </Target>
+
+</Project>

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/OrderPublisherPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/OrderPublisherPlugin.cs
@@ -1,0 +1,16 @@
+using Nop.Services.Plugins;
+
+namespace Nop.Plugin.Integration.OrderPublisher;
+
+public class OrderPublisherPlugin : BasePlugin
+{
+    public override async Task InstallAsync()
+    {
+        await base.InstallAsync();
+    }
+
+    public override async Task UninstallAsync()
+    {
+        await base.UninstallAsync();
+    }
+}

--- a/src/Plugins/Nop.Plugin.Integration.OrderPublisher/plugin.json
+++ b/src/Plugins/Nop.Plugin.Integration.OrderPublisher/plugin.json
@@ -1,0 +1,11 @@
+{
+  "Group": "Integration",
+  "FriendlyName": "Order Publisher (VerdeMart Omnichannel)",
+  "SystemName": "Integration.OrderPublisher",
+  "Version": "1.0.0",
+  "SupportedVersions": [ "5.00" ],
+  "Author": "VerdeMart Team",
+  "DisplayOrder": 1,
+  "FileName": "Nop.Plugin.Integration.OrderPublisher.dll",
+  "Description": "Publishes order events to RabbitMQ via the Outbox Pattern for omnichannel ERP/WMS integration."
+}


### PR DESCRIPTION
Closes #1

## What

Sets up the `Nop.Plugin.Integration.OrderPublisher` plugin from scratch and introduces the `OutboxMessage` entity with its database migration.

This is the foundation layer of the Outbox Pattern implementation for **Scenario C — Omnichannel Commerce Core (VerdeMart Retail)**. Nothing else in the integration pipeline can exist until nopCommerce recognises the plugin and the outbox table exists in the database.

---

## Commits

### `feat: scaffold Nop.Plugin.Integration.OrderPublisher plugin`

| File | Purpose |
|------|---------|
| `src/NopCommerce.sln` | Plugin project added to solution |
| `Nop.Plugin.Integration.OrderPublisher.csproj` | Project file — targets `net10.0`, sets output path to `Plugins/Integration.OrderPublisher`, enables `CopyLocalLockFileAssemblies` (required for RabbitMQ.Client to be deployed with the plugin) |
| `OrderPublisherPlugin.cs` | Implements `BasePlugin` with empty `InstallAsync` / `UninstallAsync` — nopCommerce lifecycle hooks |
| `plugin.json` | Plugin metadata: group `Integration`, system name `Integration.OrderPublisher`, version `1.0.0` |

nopCommerce's plugin discovery requires both `.csproj` output path and `plugin.json` to be correct before the plugin is loaded. This commit establishes that baseline so all subsequent work has a stable compilation target.

### `feat: add OutboxMessage entity and database migration`

| File | Purpose |
|------|---------|
| `Domain/OutboxMessage.cs` | Entity with fields: `EventType` (string 100), `Payload` (string MAX), `CreatedOnUtc` (DateTime), `ProcessedOnUtc` (DateTime? nullable), `CorrelationId` (string 100) |
| `Data/Mapping/Builders/OutboxMessageBuilder.cs` | `NopEntityBuilder<OutboxMessage>` — maps columns and constraints via FluentMigrator |
| `Data/Mapping/OrderPublisherNameCompatibility.cs` | `INameCompatibility` — maps the entity to table name `Integration_OutboxMessage` |
| `Data/Migrations/SchemaMigration.cs` | FluentMigrator migration tagged `2026-05-17`, `MigrationProcessType.Installation` — creates the table on plugin install, drops it on uninstall |

The `ProcessedOnUtc` nullable column is the operational indicator of the Outbox Pattern: `NULL` means pending delivery to RabbitMQ; non-null means the message was acknowledged by the broker. The `OutboxPublisherService` (Commit 4) polls on this field.

---

## Architecture traceability

| Driver | → |
|--------|---|
| **QA scenario** | Reliability — order events must not be lost if RabbitMQ is temporarily unavailable |
| **ADR** | [ADR-002 — Outbox Pattern](docs/adr/ADR-002-outbox-pattern.md) |
| **Implementation** | This PR delivers the storage layer that ADR-002 depends on |

---

## How to verify

After installing the plugin (Admin → Local plugins → Install), run the following against the nopCommerce SQL Server database:

```sql
SELECT TABLE_NAME
FROM INFORMATION_SCHEMA.TABLES
WHERE TABLE_NAME = 'Integration_OutboxMessage';
-- Expected: one row returned

SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
FROM INFORMATION_SCHEMA.COLUMNS
WHERE TABLE_NAME = 'Integration_OutboxMessage'
ORDER BY ORDINAL_POSITION;
-- Expected: Id, EventType, Payload, CreatedOnUtc, ProcessedOnUtc (nullable), CorrelationId
```

---

## What this PR does NOT include

The consumer that writes rows to this table (`OrderPlacedConsumer`) and the background service that drains them to RabbitMQ (`OutboxPublisherService`) are in the next PRs (Issues #5 and #8). This separation allows verifying the table structure independently before writing any business logic that depends on it.
